### PR TITLE
Convert keywords to uppercase in parser for deleteMod and deleteTut

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteModCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModCommandParser.java
@@ -31,7 +31,7 @@ public class DeleteModCommandParser implements Parser<DeleteModCommand> {
         }
 
         try {
-            Module module = new Module(keyword);
+            Module module = new Module(keyword.toUpperCase());
             return new DeleteModCommand(module);
         } catch (Exception e) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/DeleteModTutCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModTutCommandParser.java
@@ -27,7 +27,8 @@ public class DeleteModTutCommandParser implements Parser<DeleteModTutCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteModTutCommand.MESSAGE_USAGE));
         }
         try {
-            ModTutGroup modTutGroup = new ModTutGroup(keyword.toUpperCase()); // assumes constructor parses "CS2103T-T01"
+            // assumes constructor parses "CS2103T-T01"
+            ModTutGroup modTutGroup = new ModTutGroup(keyword.toUpperCase());
             return new DeleteModTutCommand(modTutGroup);
         } catch (IllegalArgumentException e) {
             throw new ParseException("Invalid ModTutGroup format. Expected format: MODULE-TUTORIAL", e);

--- a/src/main/java/seedu/address/logic/parser/DeleteModTutCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModTutCommandParser.java
@@ -27,7 +27,7 @@ public class DeleteModTutCommandParser implements Parser<DeleteModTutCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteModTutCommand.MESSAGE_USAGE));
         }
         try {
-            ModTutGroup modTutGroup = new ModTutGroup(keyword); // assumes constructor parses "CS2103T-T01"
+            ModTutGroup modTutGroup = new ModTutGroup(keyword.toUpperCase()); // assumes constructor parses "CS2103T-T01"
             return new DeleteModTutCommand(modTutGroup);
         } catch (IllegalArgumentException e) {
             throw new ParseException("Invalid ModTutGroup format. Expected format: MODULE-TUTORIAL", e);


### PR DESCRIPTION
Before, when u enter `deleteMod x` or `deleteTut x`, assertion error occurs.
Fixed this issue in parser by converting keyword to uppercase